### PR TITLE
Added Catalog API CLI examples for AmiProduct entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.iml

--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@
 ## AWS Marketplace Catalog API
 
 * [Documentation](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/welcome.html)
+* [AMI Product API Samples](catalog-api/products/ami)
 * [Enumerate Products (Python)](catalog-api/enumerate-products-python)
 * [Enumerate Products (Ruby)](catalog-api/enumerate-products-ruby)

--- a/catalog-api/products/ami/README.md
+++ b/catalog-api/products/ami/README.md
@@ -1,0 +1,18 @@
+# AWS Marketplace AmiProduct Samples
+API samples listed on this page make use of [jq](https://stedolan.github.io/jq/manual/) filters.
+
+#### Entity Management APIs
+* [ListEntities](list-entities): Enumerate AMI products on Marketplace that you own
+* [DescribeEntity](describe-entity): Retrieve details of an AmiProduct entity
+
+#### Change Management APIs
+**StartChangeSet:** Start Catalog API change set using one or more of the following change types
+* [add-delivery-options](add-delivery-options/README.md): Add a new version
+* [update-delivery-options](update-delivery-options/README.md): Update details of an existing version 
+* [restrict-delivery-options](restrict-delivery-options/README.md): Restrict one or more versions
+* [update-information](update-information/README.md): Update product information
+
+## API References
+
+* [AWS Marketplace AMI Products](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/ami-products.html)
+* [AWS Marketplace Catalog API](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/welcome.html)

--- a/catalog-api/products/ami/add-delivery-options/README.md
+++ b/catalog-api/products/ami/add-delivery-options/README.md
@@ -1,0 +1,78 @@
+### Language specific examples
+For examples of this Change type in one of the language-specific AWS SDKs, see the following:
+- [AWS Command Line Interface](example.sh)
+
+### Request Parameters for AddDeliveryOptions Change Type  
+  
+**Version (structure)**  
+ *Details about the software version*
+  
+ - **VersionTitle (string)**    
+   *Title of the new product version. Version title is a unique identifier of a version. Displayed to customers on the product detail and configuration pages*  
+ 
+  - **ReleaseNotes (string)**  
+    *Notes regarding changes in the version*  
+
+**DeliveryOptions (list)**  
+  *List of DeliveryOption objects with details about the delivery options of the version* 
+  
+ -  **Details (structure)**  
+  *AMI Delivery option details*  
+  
+    - **AmiDeliveryOptionDetails (structure)**      
+      *Details of AMI DeliveryOption*
+      
+        - **AmiSource (structure)**  
+         *AMI asset and asset related metadata*  
+
+             - **AmiId (string)**  
+             *Source AMI ID located in the region where CatalogMarketplace is called and should be owned by the caller account. Used by Marketplace to make regional copies and share with entitled customers*
+             
+             - **AccessRoleArn (string)**  
+             *IAM role ARN used by Marketplace to access the provided AmiId. Ensure its trust relationship contains public service principal for asset services: `assets.marketplace.amazonaws.com` and its policy permissions include ec2 permissions to clone the AMI within MP. The user should also have permission to pass the role to Marketplace. The AccessRole should be in the same account as the AMI*   
+              
+             - **UserName (string)**  
+             *Login username used to access the OS; i.e. ec2-user, ubuntu, Administrator. Used for scanning the provided AMI for vulnerabilities*
+               
+             - **ScanningPort (integer)**  
+             *Optional SSH or RDP port used to access the OS. Used for scanning the provided AMI for vulnerabilities. Defaults to 22* 
+              
+             - **OperatingSystemName (string)**  
+               *Operating system displayed to customers*
+                 
+             - **OperatingSystemVersion (string)**  
+                *Operating system version displayed to customers*   
+          
+	        - **UsageInstructions (string)**  
+	         *Information on how an end user can launch the product. Displayed to end users on the product detail and fulfillment pages*
+	           
+	         - **AccessEndpointUrl (structure)**  
+		    *Optional object for url details to a web interface for the software*
+		      
+	             - **Port (string)**  
+	               *For products with a UI interface, enter the port of the endpoint `https://<public-dns>/relativePath:port` e.g. 80, 443*
+	                 
+	             - **Protocol (string)**  
+                       *For products with a UI interface, enter the protocol of the endpoint `https://<public-dns>/relativePath:port` . Possible values: http | https*
+                         
+                  - **RelativePath (string)**  
+                    *Optional. For products with a browser interface, enter the relativePath of the endpoint `https://<public-dns>/relativePath:port`*
+  
+	         - **RecommendedInstanceType (string)**  
+                   *Default instance type the version will use with 1-Click launch and would be recommended to customers*  
+
+	         - **SecurityGroups (list)**  
+                   *List of security group objects. Ingress rules for the automatically created groups for the version*   
+          
+	            - **FromPort (integer)**  
+	             *The source port*
+	             
+	             - **IpProtocol (string)**  
+	              *The IP protocol. Possible values: tcp | udp*   
+              
+	             - **IpRanges (list)**  
+	               *List of Strings - CIDR IP ranges*
+	                 
+	             - **ToPort (integer)**  
+	               *The destination port*
+            

--- a/catalog-api/products/ami/add-delivery-options/example.sh
+++ b/catalog-api/products/ami/add-delivery-options/example.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Set details JSON
+DETAILS_JSON_AS_STRING=$(echo '
+{
+  "Version": {
+    "VersionTitle": "Sample title",
+    "ReleaseNotes": "Sample release notes"
+  },
+  "DeliveryOptions": [
+    {
+      "Details": {
+        "AmiDeliveryOptionDetails": {
+          "AmiSource": {
+            "AmiId": "ami-12345678",
+            "AccessRoleArn": "arn:aws:iam::123456789012:role/sampleRole",
+            "UserName": "Sample username",
+            "OperatingSystemName": "Sample OS",
+            "OperatingSystemVersion": "Sample OS Version"
+          },
+          "UsageInstructions": "Sample usage instructions",
+          "RecommendedInstanceType": "m4.xlarge",
+          "SecurityGroups": [
+            {
+              "IpProtocol": "tcp",
+              "FromPort": 443,
+              "ToPort": 443,
+              "IpRanges": [
+                "0.0.0.0/0"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}' | jq "tostring")
+
+# Run AWS CLI command
+# Entity identifier is same as the productId
+aws marketplace-catalog start-change-set \
+  --catalog "AWSMarketplace" \
+  --change-set '[
+      {
+        "ChangeType": "AddDeliveryOptions",
+        "Entity": {
+          "Identifier": "00000000-0000-0000-0000-000000000000",
+          "Type": "AmiProduct@1.0"
+        },
+        "Details": '"${DETAILS_JSON_AS_STRING}"'
+      }
+    ]';

--- a/catalog-api/products/ami/describe-entity/README.md
+++ b/catalog-api/products/ami/describe-entity/README.md
@@ -1,0 +1,139 @@
+### Describe an AmiProduct on Catalog API
+This sample retrieves details of an an AmiProduct using DescribeEntity operation in AWS Marketplace Catalog API. To run the sample, set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and `AWS_REGION` parameters in terminal session.
+
+```commandline
+# Run AWS CLI command
+aws marketplace-catalog describe-entity \
+  --catalog "AWSMarketplace" \
+  --entity-id "00000000-0000-0000-0000-000000000000"
+```
+
+**Response Structure**
+```
+{
+    "EntityType": "AmiProduct@1.0",
+    "EntityIdentifier": "00000000-0000-0000-0000-000000000000",
+    "EntityArn": "arn:aws:aws-marketplace:us-east-1:1234567890012:AWSMarketplace/AmiProduct/00000000-0000-0000-0000-000000000000",
+    "LastModifiedDate": "...",
+    "Details": "<ENTITY_SPECIFIC_DETAILS_AS_A_STRING>"
+}
+```
+`Details` attribute in DescribeEntity response contains the entity type specific JSON object as a string.
+
+**AmiProduct Details**
+```commandline
+# Run AWS CLI command
+aws marketplace-catalog describe-entity \
+  --catalog "AWSMarketplace" \
+  --entity-id "00000000-0000-0000-0000-000000000000" \
+  | jq -r '.Details' | jq .
+```
+
+```json
+{
+   "Versions": [
+      {
+         "Id": "10000000-0000-0000-0000-000000000000",
+         "ReleaseNotes": "Sample release notes",
+         "UpgradeInstructions": "Sample upgrade instructions",
+         "VersionTitle": "Sample version title",
+         "CreationDate": "...",
+         "Sources": [
+            {
+               "Id": "20000000-0000-0000-0000-000000000000",
+               "Type": "AmazonMachineImage",
+               "Image": "ami-12345678",
+               "Architecture": "x86_64",
+               "VirtualizationType": "hvm",
+               "OperatingSystem": {
+                  "Name": "AMAZONLINUX",
+                  "Version": "1.0",
+                  "Username": "ec2-user",
+                  "ScanningPort": 22
+               },
+               "Compatibility": {
+                  "AvailableInstanceTypes": [
+                     "m4.xlarge",
+                     "c5.large"
+                  ],
+                  "RestrictedInstanceTypes": [
+                     "t2.micro"
+                  ]
+               }
+            }
+         ],
+         "DeliveryOptions": [
+            {
+               "Id": "30000000-0000-0000-0000-000000000000",
+               "Type": "AmazonMachineImage",
+               "SourceId": "20000000-0000-0000-0000-000000000000",
+               "ShortDescription": "Sample description",
+               "Instructions": {
+                  "Usage": "Sample usage instructions"
+               },
+               "Recommendations": {
+                  "SecurityGroups": [
+                     {
+                        "Protocol": "tcp",
+                        "FromPort": 443,
+                        "ToPort": 443,
+                        "CidrIps": ["0.0.0.0./0"]
+                     }
+                  ],
+                  "InstanceType": "m4.xlarge"
+               },
+               "Visibility": "Public",
+               "Title": "(X86_64) Amazon Machine Image"
+            }
+         ]
+      }
+   ],
+   "Description": {
+      "Highlights": [
+         "Sample highlight"
+      ],
+      "ProductCode": "0000001111",
+      "SearchKeywords": [
+         "Sample keyword"
+      ],
+      "ProductTitle": "Sample product title",
+      "ShortDescription": "Brief description",
+      "LongDescription": "Detailed description",
+      "Manufacturer": "Sample vendor name",
+      "Visibility": "Public",
+      "AssociatedProducts": [],
+      "Sku": "SKU-1234",
+      "Categories": [
+         "Sample category"
+      ]
+   },
+   "PromotionalResources": {
+      "LogoUrl": "https://sample.amazonaws.com/logo.png",
+      "Videos": [
+         {
+            "Type": "Link",
+            "Title": "Sample video",
+            "Url": "https://sample.amazonaws.com/play.html"
+         }
+      ],
+      "AdditionalResources": [
+         {
+            "Type": "Link",
+            "Text": "Sample text",
+            "Url": "https://sample.amazonaws.com/learn.html"
+         }
+      ]
+   },
+   "SupportInformation": {
+      "Description": "Sample information",
+      "Resources": []
+   },
+   "RegionAvailability": {
+      "Regions": [
+         "us-east-1",
+         "eu-west-1"
+      ],
+      "FutureRegionSupport": "All"
+   }
+}
+```

--- a/catalog-api/products/ami/list-entities/README.md
+++ b/catalog-api/products/ami/list-entities/README.md
@@ -1,0 +1,26 @@
+### List AmiProduct entities on Catalog API
+This sample retrieves all AmiProduct entities owned by a vendor account using ListEntities operation in AWS Marketplace Catalog API. To run the sample, set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and `AWS_REGION` parameters in terminal session.
+
+```
+# Run AWS CLI command
+aws marketplace-catalog list-entities \
+  --catalog "AWSMarketplace" \
+  --entity-type "AmiProduct"
+```
+
+**Response Structure**
+```
+{
+    "EntitySummaryList": [
+        {
+            "Name": "Sample entity name",
+            "EntityType": "AmiProduct",
+            "EntityId": "00000000-0000-0000-0000-000000000000",
+            "EntityArn": "arn:aws:aws-marketplace:us-east-1:123456789012:AWSMarketplace/AmiProduct/00000000-0000-0000-0000-000000000000",
+            "LastModifiedDate": "...",
+            "Visibility": "Public"
+        }
+    ],
+    "NextToken": "..."
+}
+```

--- a/catalog-api/products/ami/restrict-delivery-options/README.md
+++ b/catalog-api/products/ami/restrict-delivery-options/README.md
@@ -1,0 +1,8 @@
+### Language specific examples
+For examples of this Change type in one of the language-specific AWS SDKs, see the following:
+- [AWS Command Line Interface](example.sh)
+
+### Request Parameters for RestrictDeliveryOptions Change Type  
+
+**DeliveryOptionIds (list)**  
+*List of DeliveryOptionIds to restrict. At least one deliveryOption of the product should remain `Public` to customers*

--- a/catalog-api/products/ami/restrict-delivery-options/example.sh
+++ b/catalog-api/products/ami/restrict-delivery-options/example.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Set the title of version to restrict
+VERSION_TITLE_TO_RESTRICT="new-version"
+
+# Extract DeliveryOptionId for the version to restrict
+DELIVERY_OPT_ID=$(aws marketplace-catalog describe-entity \
+  --catalog AWSMarketplace \
+  --entity-id 09c969cd-8db3-4c87-9181-a9d45602267d \
+  --query 'Details' --output text |
+  jq '.Versions[] | select(.VersionTitle == "'"${VERSION_TITLE_TO_RESTRICT}"'") | .DeliveryOptions[].Id')
+
+if [ -z "$DELIVERY_OPT_ID" ]; then
+  echo "Version with title '${VERSION_TITLE_TO_RESTRICT}' not found"
+  exit 1
+fi
+
+# Set details JSON
+DETAILS_JSON_AS_STRING=$(echo '
+{
+  "DeliveryOptionIds": [
+    '${DELIVERY_OPT_ID}'
+  ]
+}' | jq "tostring")
+
+# Run AWS CLI command
+# Entity identifier is same as the productId
+aws marketplace-catalog start-change-set \
+  --catalog "AWSMarketplace" \
+  --change-set '[
+      {
+        "ChangeType": "RestrictDeliveryOptions",
+        "Entity": {
+          "Identifier": "10000000-0000-0000-0000-000000000000",
+          "Type": "AmiProduct@1.0"
+        },
+        "Details": '"${DETAILS_JSON_AS_STRING}"'
+      }
+    ]'

--- a/catalog-api/products/ami/update-delivery-options/README.md
+++ b/catalog-api/products/ami/update-delivery-options/README.md
@@ -1,0 +1,55 @@
+### Language specific examples
+For examples of this Change type in one of the language-specific AWS SDKs, see the following:
+- [AWS Command Line Interface](example.sh)
+
+### Request Parameters for UpdateDeliveryOptions Change Type   
+
+**Version (structure)**    
+ *Details about the software version to be updated*  
+ - **ReleaseNotes (string)**    
+ *Optional. Notes regarding changes in the version*   
+
+**DeliveryOptions (list)**    
+ *List of DeliveryOption objects with details about the delivery options of the version*   
+    
+- **Id (string)**  
+  *Unique identifier for DeliveryOption*  
+  
+ - **Details (structure)**    
+ *Details of the DeliveryOption to be updated. The delivery option title can only be changed for DeliveryOptions which have not been released to customers*    
+    
+   - **AmiDeliveryOptionDetails (structure)**        
+ *Details of AMI DeliveryOption*  
+            
+		- **UsageInstructions (string)**    
+ *Optional. Instructions on launching the product. Displayed to customers on the product detail and fulfillment pages. Defaults to the existing value in this version.*  
+
+	 - **AccessEndpointUrl (structure)**    
+ *Optional. Object for url details to a web interface for the software*  
+
+		 - **Port (string)**    
+		 *For products with a UI interface, enter the port of the endpoint `https://<public-dns>/relativePath:port` e.g. 80, 443*  
+
+		 - **Protocol (string)**    
+		 *For products with a UI interface, enter the protocol of the endpoint `https://<public-dns>/relativePath:port` . Possible values: http | https*  
+
+		 - **RelativePath (string)**    
+		 *Optional. For products with a browser interface, enter the relativePath of the endpoint `https://<public-dns>/relativePath:port`*  
+
+	 - **RecommendedInstanceType (string)**    
+	  *Optional. Default instance type the version will use with 1-Click launch and would be recommended to customers. Defaults to the existing value in version*   
+ 
+	 - **SecurityGroups (list)**    
+ *Optional. List of security group objects. Ingress rules for the automatically created groups for the version. Defaults to the existing value in version*     
+            
+		- **FromPort (integer)**    
+		 *The source port*  
+
+		 - **IpProtocol (string)**    
+		 *The IP protocol. Possible values: tcp | udp*     
+		                
+		- **IpRanges (list)**    
+		 *List of Strings - CIDR IP ranges*  
+
+		 - **ToPort (integer)**    
+		 *The destination port*

--- a/catalog-api/products/ami/update-delivery-options/example.sh
+++ b/catalog-api/products/ami/update-delivery-options/example.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Set details JSON
+DETAILS_JSON_AS_STRING=$(echo '
+{
+  "Version": {
+    "ReleaseNotes": "Updated release notes"
+  },
+  "DeliveryOptions": [
+    {
+      "Id": "00000000-0000-0000-0000-000000000000",
+      "Details": {
+        "AmiDeliveryOptionDetails": {
+          "UsageInstructions": "Updated usage instructions",
+          "RecommendedInstanceType": "m4.2xlarge",
+          "AccessEndpointUrl": {
+            "Port": 8080,
+            "Protocol": "https",
+            "RelativePath": "index.html"
+          },
+          "SecurityGroups": [
+            {
+              "IpProtocol": "tcp",
+              "FromPort": 443,
+              "ToPort": 443,
+              "IpRanges": [
+                "0.0.0.0/0"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}' | jq "tostring")
+
+# Run AWS CLI command
+# Entity identifier is same as the productId
+aws marketplace-catalog start-change-set \
+  --catalog "AWSMarketplace" \
+  --change-set '[
+      {
+        "ChangeType": "UpdateDeliveryOptions",
+        "Entity": {
+          "Identifier": "10000000-0000-0000-0000-000000000000",
+          "Type": "AmiProduct@1.0"
+        },
+        "Details": '"${DETAILS_JSON_AS_STRING}"'
+      }
+    ]';

--- a/catalog-api/products/ami/update-information/README.md
+++ b/catalog-api/products/ami/update-information/README.md
@@ -1,0 +1,44 @@
+### Language specific examples
+For examples of this Change type in one of the language-specific AWS SDKs, see the following:
+- [AWS Command Line Interface](example.sh)
+
+### Request Parameters for UpdateInformation Change Type  
+
+**ProductTitle (string)**  
+*Optional. Updated name of the product to be displayed to customers*  
+  
+**ShortDescription (string)**  
+*Optional. Brief description of key aspects of the product to be displayed to customers*  
+  
+**LongDescription (string)**  
+*Optional. Detailed description of the product to be displayed to customers*  
+  
+**Sku (string)**  
+*Optional. Free-form string field for sellers to define and use as a reference to product in their own catalog*  
+  
+**LogoUrl (string)**  
+*Optional. S3 link to an image to be displayed to customers in `PNG` or `JPG` format. The image should be hosted in a public s3 bucket or a pre-signed URL to the image hosted in a private bucket*  
+  
+**VideoUrls (string list)**  
+*Optional. List of links to an externally hosted video to be provided as reference to customers on Marketplace website* 
+  
+**Highlights (string list)**  
+*Optional. Short bullet style call outs of key product features*  
+  
+**AdditionalResources (structure list)**  
+*Optional. References to additional resources to learn about the product to be displayed to customers*  
+  
+ - **Text (string)**  
+*Displayed as text to corresponding hyperlink*  
+  
+ - **Url (string)**  
+*URL for the corresponding resource text*
+  
+**SupportDescription (string)**  
+*Optional. Contact details and URLs to reach the support group of the product if support is offered*  
+  
+**Categories (string list)**  
+*Optional. Category for your product selected from a pre-defined list of product categories identified by Marketplace*  
+  
+**SearchKeywords (string list)**  
+*Optional. Additional keywords for the product for search experience. Seller and Product name along with product categories are automatically added for search*

--- a/catalog-api/products/ami/update-information/example.sh
+++ b/catalog-api/products/ami/update-information/example.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Set details JSON
+# Properties that don't require an update can be omitted
+DETAILS_JSON_AS_STRING=$(echo '
+{
+  "ProductTitle": "Sample product",
+  "ShortDescription": "Brief description",
+  "LongDescription": "Detailed description",
+  "Sku": "SKU-123",
+  "LogoUrl": "https://s3.amazonaws.com/logos/sample.png",
+  "VideoUrls": [
+    "https://sample.amazonaws.com/awsmp-video-1",
+    "https://sample.amazonaws.com/awsmp-video-2"
+  ],
+  "Highlights": [
+    "Sample highlight"
+  ],
+  "AdditionalResources": [
+    {
+      "Text": [
+        "Sample resource",
+        "https://sample.amazonaws.com"
+      ]
+    }
+  ],
+  "SupportDescription": "Product support information",
+  "Categories": [
+    "Operating Systems"
+  ],
+  "SearchKeywords": [
+    "Sample keyword"
+  ]
+}' | jq "tostring")
+
+# Run AWS CLI command
+# Entity identifier is same as the productId
+aws marketplace-catalog start-change-set \
+  --catalog "AWSMarketplace" \
+  --change-set '[
+      {
+        "ChangeType": "UpdateInformation",
+        "Entity": {
+          "Identifier": "10000000-0000-0000-0000-000000000000",
+          "Type": "AmiProduct@1.0"
+        },
+        "Details": '"${DETAILS_JSON_AS_STRING}"'
+      }
+    ]';


### PR DESCRIPTION
*Description of changes:*
Added AWS CLI examples for 
 - DescribeEntity, and ListEntities operations
 - AddDeliveryOptions, RestrictDeliveryOptions, UpdateDeliveryOptions, UpdateInformation change types

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
